### PR TITLE
Using camel-snake-kebab 0.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
    [org.clojure/tools.logging  "0.3.1"]
    [org.clojure/algo.generic   "0.1.2"]
 
-   [camel-snake-kebab           "0.2.5"]
+   [camel-snake-kebab           "0.3.0"]
 
    [http-kit                   "2.1.18"]
    [com.cemerick/url           "0.1.1"]

--- a/src/eulalie/dynamo.clj
+++ b/src/eulalie/dynamo.clj
@@ -7,7 +7,7 @@
             [eulalie :refer :all]
             [cheshire.core :as cheshire]
             [clojure.core.async :as async]
-            [camel-snake-kebab.core :refer [->CamelCaseString ->kebab-case-keyword]]))
+            [camel-snake-kebab.core :refer [->PascalCaseString ->kebab-case-keyword]]))
 
 ;; FIXME how do we handle errors in the body like {__type:} in a
 ;; general way?

--- a/src/eulalie/dynamo/mapping.clj
+++ b/src/eulalie/dynamo/mapping.clj
@@ -5,7 +5,7 @@
    [clojure.algo.generic.functor :as functor]
    [clojure.string  :as str]
    [camel-snake-kebab.core
-    :refer [->SNAKE_CASE_KEYWORD ->kebab-case-keyword ->CamelCaseKeyword]]))
+    :refer [->SCREAMING_SNAKE_CASE_KEYWORD ->kebab-case-keyword ->PascalCaseKeyword]]))
 
 (defn handle-attr [f v]
   (functor/fmap
@@ -25,12 +25,12 @@
 
 (defn transform-request [m]
   (transform
-   ->CamelCaseKeyword
+   ->PascalCaseKeyword
    identity
    key-types/request-key-types
    {:nest transform-request
     :attr #(handle-attr transform-request %)
-    :enum ->SNAKE_CASE_KEYWORD
+    :enum ->SCREAMING_SNAKE_CASE_KEYWORD
     :list (fn-some->> not-empty (map name) (str/join ","))}
    m))
 

--- a/src/eulalie/service_util.clj
+++ b/src/eulalie/service_util.clj
@@ -7,8 +7,8 @@
    [clj-time.coerce :as time-coerce]
    [cemerick.url :as url]
    [camel-snake-kebab.core :refer
-    [->CamelCaseKeyword
-     ->CamelCaseString
+    [->PascalCaseKeyword
+     ->PascalCaseString
      ->kebab-case-keyword]]
    [camel-snake-kebab.extras :refer [transform-keys]])
   (:import java.util.zip.CRC32))
@@ -110,17 +110,17 @@
 (def aws-date-format      (time-format/formatters :basic-date))
 (def aws-date-time-format (time-format/formatters :basic-date-time-no-ms))
 
-(def ->camel-k ->CamelCaseKeyword)
+(def ->camel-k ->PascalCaseKeyword)
 (def ->kebab-k ->kebab-case-keyword)
-(def ->camel-s ->CamelCaseString)
+(def ->camel-s ->PascalCaseString)
 
 (defn ->camel [x]
   (if (string? x)
     (->camel-s x)
     (->camel-k x)))
 
-(def ->camel-keys-k (partial transform-keys ->CamelCaseKeyword))
-(def ->camel-keys-s (partial transform-keys ->CamelCaseString))
+(def ->camel-keys-k (partial transform-keys ->PascalCaseKeyword))
+(def ->camel-keys-s (partial transform-keys ->PascalCaseString))
 
 (defn region->tld [region]
   (case (name region)

--- a/src/eulalie/sns.clj
+++ b/src/eulalie/sns.clj
@@ -56,7 +56,7 @@
   (defn prepare-targeted-message [msg]
     (into {}
       (for [[k v] msg]
-        (let [k' (csk/->SNAKE_CASE_KEYWORD k)
+        (let [k' (csk/->SCREAMING_SNAKE_CASE_KEYWORD k)
               k  (if (upper-case k') k' k)
               v  (prepare-message-value
                   (dispatch-map k k)

--- a/src/eulalie/util/query.clj
+++ b/src/eulalie/util/query.clj
@@ -28,9 +28,9 @@
   (cond (and (keyword? k) (namespace k))
         (str (str/lower-case (namespace k))
              ":"
-             (csk/->CamelCaseString (name k)))
+             (csk/->PascalCaseString (name k)))
         (string? k) k
-        :else (csk/->CamelCaseString k)))
+        :else (csk/->PascalCaseString k)))
 
 (defn policy-key-in [k]
   (let [k (cond-> k (keyword? k) name)]
@@ -74,8 +74,8 @@
 (defn translate-enums [req enum-keys]
   (let [matcher (enum-keys->matcher enum-keys)]
     (into req
-      (for [[k v] req :when (matcher k)]
-        [k (cond-> v (keyword? v) csk/->CamelCaseString)]))))
+          (for [[k v] req :when (matcher k)]
+            [k (cond-> v (keyword? v) csk/->PascalCaseString)]))))
 
 (defn join-key-paths [& segments]
   (vec (flatten (apply conj [] segments))))
@@ -96,7 +96,7 @@
         (let [k (flatten k)]
           (str/join "." (map format-query-key k)))
         (string?  k) k
-        (keyword? k) (csk/->CamelCaseString k)
+        (keyword? k) (csk/->PascalCaseString k)
         :else        (str k)))
 
 (defn format-query-request [m]
@@ -153,7 +153,7 @@
   [{:keys [version] :as service} {:keys [body target] :as req}]
   (let [body (assoc body
                     :version version
-                    :action (csk/->CamelCaseString target))]
+                    :action (csk/->PascalCaseString target))]
     (-> (service-util/default-request service req)
         (assoc :body body)
         (assoc-in [:headers :content-type]


### PR DESCRIPTION
To avoid AOT problems on case-insensitive file systems.

See [camel-snake-kebab 2015-01-17: 0.3.0](https://github.com/qerub/camel-snake-kebab/blob/stable/README.md#2015-01-17-030) for more information.
