### PR TITLE
Add methods to create and delete lambda functions.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject io.nervous/eulalie "0.6.8"
+(defproject io.nervous/eulalie "0.7.0-SNAPSHOT"
   :description "Asynchronous, pure-Clojure AWS client"
   :url "https://github.com/nervous-systems/eulalie"
   :license {:name "Unlicense" :url "http://unlicense.org/UNLICENSE"}

--- a/src/eulalie/lambda.cljc
+++ b/src/eulalie/lambda.cljc
@@ -64,11 +64,8 @@
     {:eulalie.lambda/invocation-type invocation-type}))
 
 (defmethod prepare-request :create-function
-  [{:keys [body] :as req}]
-  (assoc req
-    :body (->>
-            body
-            (csk-extras/transform-keys csk/->PascalCaseString))))
+  [req]
+  (update req :body #(csk-extras/transform-keys csk/->PascalCaseString %1)))
 
 (defmethod prepare-request :delete-function
   [req]

--- a/src/eulalie/lambda.cljc
+++ b/src/eulalie/lambda.cljc
@@ -35,9 +35,11 @@
 (def versioned-fn-url (into fn-url ["versions" ::version]))
 
 (def target->url
-  {:add-permission [:post (conj versioned-fn-url "policy")]
-   :get-function   [:get  versioned-fn-url]
-   :invoke         [:post (conj fn-url "invocations")]})
+  {:add-permission  [:post (conj versioned-fn-url "policy")]
+   :get-function    [:get  versioned-fn-url]
+   :invoke          [:post (conj fn-url "invocations")]
+   :create-function [:post [service-version "functions"]]
+   :delete-function [:delete fn-url]})
 
 (defmulti prepare-request :target)
 
@@ -60,6 +62,17 @@
       :body payload
       :headers (body->headers body))
     {:eulalie.lambda/invocation-type invocation-type}))
+
+(defmethod prepare-request :create-function
+  [{:keys [body] :as req}]
+  (assoc req
+    :body (->>
+            body
+            (csk-extras/transform-keys csk/->PascalCaseString))))
+
+(defmethod prepare-request :delete-function
+  [req]
+  req)
 
 (defn- build-endpoint
   [{:keys [endpoint target] {fn-name :function-name :as body} :body :as req}]
@@ -117,7 +130,7 @@
       response
       {:log-result (some-> headers :x-amz-log-result parse-log-result)})))
 
-(defmethod transform-response-body :get-function [{:keys [body]}]
+(defmethod transform-response-body :default [{:keys [body]}]
   (->> body
        platform/decode-json
        (csk-extras/transform-keys csk/->kebab-case-keyword)))

--- a/test/eulalie/test/lambda.cljc
+++ b/test/eulalie/test/lambda.cljc
@@ -1,16 +1,38 @@
 (ns eulalie.test.lambda
   (:require [eulalie.lambda.util :as lu]
-            #? (:clj [clojure.test :refer [testing]]
-                :cljs [cljs.test :refer-macros [testing]])
+            [eulalie.lambda :as l]
+    #?(:clj [clojure.test :refer [testing]]
+       :cljs [cljs.test :refer-macros [testing]])
             [eulalie.test.common :refer [issue-raw! creds]]
-            [glossop.core #? (:clj :refer :cljs :refer-macros) [go-catching <?]]
-            [eulalie.test.common :as test.common
-             #? (:clj :refer :cljs :refer-macros) [deftest is]]
-            [eulalie.util :refer [env!]]))
+            [glossop.core #?(:clj :refer :cljs :refer-macros) [go-catching <?]]
+            [eulalie.test.common #?(:clj :refer :cljs :refer-macros) [deftest is]]
+            [eulalie.util :refer [env!]]
+            [eulalie.core :as e]
+            [clojure.string :as str]
+            [camel-snake-kebab.core :as csk]
+            [camel-snake-kebab.extras :as csk-extras]))
 
 (def lambda-role-arn (env! "LAMBDA_ROLE_ARN"))
 (def function-zipped "UEsDBAoAAAAAAEBL+0iHxOHaUwAAAFMAAAAHAAAAdGVzdC5qc2V4cG9ydHMuaGFuZGxlciA9IChldmVudCwgY29udGV4dCwgY2FsbGJhY2spID0+IHsgY2FsbGJhY2sobnVsbCwgIkhlbGxvIHdvcmxkIik7IH07UEsBAhQACgAAAAAAQEv7SIfE4dpTAAAAUwAAAAcAAAAAAAAAAAAAAAAAAAAAAHRlc3QuanNQSwUGAAAAAAEAAQA1AAAAeAAAAAAA")
 (defn function-name [] (str "eulalie-test-" (rand-int 2147483647))) ;JVM Integer/MAX_VALUE
+
+(deftest mapping-test
+  (let [function-name (function-name)
+        req {:creds creds
+             :service :lambda
+             :target :create-function
+             :body {:code {:zip-file function-zipped}
+                    :function-name function-name
+                    :handler "test.handler"
+                    :role lambda-role-arn
+                    :runtime "nodejs4.3"}}
+        {:keys [body method endpoint]} (e/prepare-req req)]
+    (is (= (->> (cheshire.core/parse-string body true)
+                (csk-extras/transform-keys csk/->kebab-case))
+           (:body req)))
+    (is (str/starts-with? (:host endpoint) "lambda"))
+    (is (= (:path endpoint) (str "/" l/service-version "/functions")))
+    (is (= :post method))))
 
 (deftest ^:integration ^:aws create-test-function
          (if (not-empty (:secret-key creds))

--- a/test/eulalie/test/lambda.cljc
+++ b/test/eulalie/test/lambda.cljc
@@ -1,7 +1,8 @@
 (ns eulalie.test.lambda
   (:require [eulalie.lambda.util :as lu]
             [eulalie.lambda :as l]
-    #?(:clj [clojure.test :refer [testing]]
+    #?(:clj
+            [clojure.test :refer [testing]]
        :cljs [cljs.test :refer-macros [testing]])
             [eulalie.test.common :refer [issue-raw! creds]]
             [glossop.core #?(:clj :refer :cljs :refer-macros) [go-catching <?]]
@@ -10,7 +11,8 @@
             [eulalie.core :as e]
             [clojure.string :as str]
             [camel-snake-kebab.core :as csk]
-            [camel-snake-kebab.extras :as csk-extras]))
+            [camel-snake-kebab.extras :as csk-extras]
+            [eulalie.platform :as platform]))
 
 (def lambda-role-arn (env! "LAMBDA_ROLE_ARN"))
 (def function-zipped "UEsDBAoAAAAAAEBL+0iHxOHaUwAAAFMAAAAHAAAAdGVzdC5qc2V4cG9ydHMuaGFuZGxlciA9IChldmVudCwgY29udGV4dCwgY2FsbGJhY2spID0+IHsgY2FsbGJhY2sobnVsbCwgIkhlbGxvIHdvcmxkIik7IH07UEsBAhQACgAAAAAAQEv7SIfE4dpTAAAAUwAAAAcAAAAAAAAAAAAAAAAAAAAAAHRlc3QuanNQSwUGAAAAAAEAAQA1AAAAeAAAAAAA")
@@ -27,7 +29,8 @@
                     :role lambda-role-arn
                     :runtime "nodejs4.3"}}
         {:keys [body method endpoint]} (e/prepare-req req)]
-    (is (= (->> (cheshire.core/parse-string body true)
+    (is (= (->> body
+                (platform/decode-json)
                 (csk-extras/transform-keys csk/->kebab-case))
            (:body req)))
     (is (str/starts-with? (:host endpoint) "lambda"))

--- a/test/eulalie/test/lambda.cljc
+++ b/test/eulalie/test/lambda.cljc
@@ -1,0 +1,39 @@
+(ns eulalie.test.lambda
+  (:require [eulalie.lambda.util :as lu]
+            #? (:clj [clojure.test :refer [testing]]
+                :cljs [cljs.test :refer-macros [testing]])
+            [eulalie.test.common :refer [issue-raw! creds]]
+            [glossop.core #? (:clj :refer :cljs :refer-macros) [go-catching <?]]
+            [eulalie.test.common :as test.common
+             #? (:clj :refer :cljs :refer-macros) [deftest is]]
+            [eulalie.util :refer [env!]]))
+
+(def lambda-role-arn (env! "LAMBDA_ROLE_ARN"))
+(def function-zipped "UEsDBAoAAAAAAEBL+0iHxOHaUwAAAFMAAAAHAAAAdGVzdC5qc2V4cG9ydHMuaGFuZGxlciA9IChldmVudCwgY29udGV4dCwgY2FsbGJhY2spID0+IHsgY2FsbGJhY2sobnVsbCwgIkhlbGxvIHdvcmxkIik7IH07UEsBAhQACgAAAAAAQEv7SIfE4dpTAAAAUwAAAAcAAAAAAAAAAAAAAAAAAAAAAHRlc3QuanNQSwUGAAAAAAEAAQA1AAAAeAAAAAAA")
+(defn function-name [] (str "eulalie-test-" (rand-int 2147483647))) ;JVM Integer/MAX_VALUE
+
+(deftest ^:integration ^:aws create-test-function
+         (if (not-empty (:secret-key creds))
+           (let [function-name (function-name)]
+             (go-catching
+               (testing "Create function"
+                 (is (= 201 (get-in (<? (issue-raw! {:creds creds
+                                                     :service :lambda
+                                                     :target :create-function
+                                                     :body {:code {:zip-file function-zipped}
+                                                            :function-name function-name
+                                                            :handler "test.handler"
+                                                            :role lambda-role-arn
+                                                            :runtime "nodejs4.3"}}))
+                                    [:response :status]))))
+               (testing "Invoke function"
+                 (is (= [:ok "Hello world"]
+                        (<? (lu/invoke! creds function-name :request-response {})))))
+               (testing "Delete function"
+                 (is (= 204 (get-in (<? (issue-raw! {:creds creds
+                                                     :service :lambda
+                                                     :method :delete
+                                                     :target :delete-function
+                                                     :body {:function-name function-name}}))
+                                    [:response :status]))))))
+           (println "Warning: Skipping remote test due to unset AWS_SECRET_KEY")))

--- a/test/eulalie/test/runner.cljs
+++ b/test/eulalie/test/runner.cljs
@@ -15,7 +15,8 @@
             [eulalie.test.sts]
             [eulalie.test.cognito]
             [eulalie.test.cognito-sync]
-            [eulalie.test.elastic-transcoder]))
+            [eulalie.test.elastic-transcoder]
+            [eulalie.test.lambda]))
 
 (doo-tests
  'eulalie.test.core
@@ -32,4 +33,5 @@
  'eulalie.test.sts
  'eulalie.test.cognito
  'eulalie.test.cognito-sync
- 'eulalie.test.elastic-transcoder)
+ 'eulalie.test.elastic-transcoder
+ 'eulalie.test.lambda)


### PR DESCRIPTION
Deletion was a little odd, since function-name has to be passed in
the body of the request, but is actually used in the url. And method
always has to be passed as :delete.

These could be wrapped in the utils namespace to make them easier to use,
but it's possibly better to alter their use in the core lambda ns.

The base64 string in the test ns was created from the test.js file in the
project here: https://github.com/lfn3/node-cljs-zip
