### PR TITLE
Bump prismatic/plumbing to fix cljs compilation issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
    [org.clojure/core.async     "0.2.395"]
 
    [io.nervous/glossop         "0.2.1"]
-   [prismatic/plumbing         "0.5.3"]
+   [prismatic/plumbing         "0.5.5"]
 
    [camel-snake-kebab          "0.4.0"]
 


### PR DESCRIPTION
Originating from this: https://github.com/plumatic/schema/issues/392

New version of plumbing: https://github.com/plumatic/plumbing/pull/133